### PR TITLE
feat: rclone setup

### DIFF
--- a/home/profiles/polaris/default.nix
+++ b/home/profiles/polaris/default.nix
@@ -3,8 +3,9 @@
     ../../editors
     ../../git.nix
     ../../gnupg.nix
-    ../../pcmanfm.nix
     ../../noise.nix
+    ../../pcmanfm.nix
+    ../../udiskie.nix
     ../../xdg.nix
 
     ../../config

--- a/home/udiskie.nix
+++ b/home/udiskie.nix
@@ -1,0 +1,3 @@
+{
+  services.udiskie.enable = true;
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,6 +6,7 @@
     ./jellyfin.nix
     ./security.nix
     ./shared.nix
+    ./rclone.nix
     ./virt-manager.nix
     ./xdg.nix
   ];

--- a/modules/rclone.nix
+++ b/modules/rclone.nix
@@ -1,0 +1,39 @@
+{pkgs, ...}: {
+  environment.systemPackages = [pkgs.rclone];
+  systemd.services = {
+    # TODO: Find a way to refer to username, should I store it
+    # in a var or is there a fancier way?
+    # also enable will fail if remote doesn't exist '-'
+    rclone-gdrive = let
+      gdrive = "/home/supeen/Documents/Drive";
+      flags = ''
+        --allow-other \
+        --dir-cache-time 48h \
+        --drive-chunk-size 512M \
+        --vfs-cache-mode full \
+        --vfs-read-chunk-size 32M \
+        --vfs-read-chunk-size-limit 2G \
+        --buffer-size 1G \
+        --bwlimit 8.5M:off \
+        --stats 1m \
+        --retries-sleep 60m \
+        --log-level INFO
+      '';
+    in {
+      enable = true;
+      description = "RClone Google Drive Service";
+      wants = ["network-online.target"];
+      after = ["network-online.target"];
+      wantedBy = ["multi-user.target"];
+
+      serviceConfig = {
+        Type = "simple";
+        Environment = "RCLONE_CONFIG=/home/supeen/.config/rclone/rclone.conf";
+        Restart = "on-failure";
+        RestartSec = 10;
+        ExecStart = "${pkgs.rclone}/bin/rclone mount gdrive: ${gdrive} \ ${flags}";
+        ExecStop = "${pkgs.fuse}/bin/fusermount -uz ${gdrive}";
+      };
+    };
+  };
+}

--- a/modules/shared.nix
+++ b/modules/shared.nix
@@ -87,6 +87,7 @@
     };
     tumbler.enable = true;
     udev.packages = [pkgs.gnome.gnome-settings-daemon];
+    udisks2.enable = true;
     xserver.xkb = {
       layout = "br";
       variant = "";


### PR DESCRIPTION
This PR enables rclone with automount for Google Drive.
As there isn't a nix module for it, manual intervention with 'rclone config' is still needed for proper setup.
Udisks2 and udiskie should help with another old problem: ntfs drives being corrupted. I mean, who uses NTFS pen drives in this day and age?